### PR TITLE
Fix PC boxes wiped after save: save layout overflows the 32-sector flash

### DIFF
--- a/include/pokemon_storage_system.h
+++ b/include/pokemon_storage_system.h
@@ -1,7 +1,11 @@
 #ifndef GUARD_POKEMON_STORAGE_SYSTEM_H
 #define GUARD_POKEMON_STORAGE_SYSTEM_H
 
-#define TOTAL_BOXES_COUNT       14
+// Reduced from 14 to 13 so struct PokemonStorage fits in 8 flash sectors instead of 9.
+// That keeps NUM_SECTORS_PER_SLOT at 14 and SECTORS_COUNT at 32 (the chip's physical
+// limit); at 14 boxes the save layout needed 34 logical sectors and aliased flash bank 0,
+// silently corrupting PC storage. See include/save.h and src/save.c STATIC_ASSERTs.
+#define TOTAL_BOXES_COUNT       13
 #define IN_BOX_ROWS             5 // Number of rows, 6 Pokémon per row
 #define IN_BOX_COLUMNS          6 // Number of columns, 5 Pokémon per column
 #define IN_BOX_COUNT            (IN_BOX_ROWS * IN_BOX_COLUMNS)

--- a/include/save.h
+++ b/include/save.h
@@ -20,14 +20,20 @@
 #define SECTOR_ID_SAVEBLOCK1_START    1
 #define SECTOR_ID_SAVEBLOCK1_END      5
 #define SECTOR_ID_PKMN_STORAGE_START  6
-#define SECTOR_ID_PKMN_STORAGE_END   14
-#define NUM_SECTORS_PER_SLOT         15
-// Save Slot 1: 0-14;  Save Slot 2: 15-29
-#define SECTOR_ID_HOF_1              30
-#define SECTOR_ID_HOF_2              31
-#define SECTOR_ID_TRAINER_HILL       32
-#define SECTOR_ID_RECORDED_BATTLE    33
-#define SECTORS_COUNT                34
+#define SECTOR_ID_PKMN_STORAGE_END   13
+#define NUM_SECTORS_PER_SLOT         14
+// Save Slot 1: 0-13;  Save Slot 2: 14-27
+#define SECTOR_ID_HOF_1              28
+#define SECTOR_ID_HOF_2              29
+#define SECTOR_ID_TRAINER_HILL       30
+#define SECTOR_ID_RECORDED_BATTLE    31
+#define SECTORS_COUNT                32
+
+// The save flash is 1 Mbit = 32 physical 4 KiB sectors (SECTORS_PER_BANK * 2 banks).
+// Logical sector N is accessed as bank (N / 16), physical (N % 16); with only two
+// banks any logical sector >= 32 silently aliases bank 0 and overwrites SaveBlock
+// data, corrupting the save (this is what wiped PC boxes). Keep SECTORS_COUNT below.
+#define MAX_PHYSICAL_SECTORS         32
 
 #define NUM_HOF_SECTORS 2
 

--- a/src/save.c
+++ b/src/save.c
@@ -72,8 +72,7 @@ struct
     SAVEBLOCK_CHUNK(struct PokemonStorage, 4),
     SAVEBLOCK_CHUNK(struct PokemonStorage, 5),
     SAVEBLOCK_CHUNK(struct PokemonStorage, 6),
-    SAVEBLOCK_CHUNK(struct PokemonStorage, 7),
-    SAVEBLOCK_CHUNK(struct PokemonStorage, 8), // SECTOR_ID_PKMN_STORAGE_END
+    SAVEBLOCK_CHUNK(struct PokemonStorage, 7), // SECTOR_ID_PKMN_STORAGE_END
 };
 
 // These will produce an error if a save struct is larger than the space
@@ -82,6 +81,10 @@ STATIC_ASSERT(sizeof(struct SaveBlock3) <= SAVE_BLOCK_3_CHUNK_SIZE * NUM_SECTORS
 STATIC_ASSERT(sizeof(struct SaveBlock2) <= SECTOR_DATA_SIZE, SaveBlock2FreeSpace);
 STATIC_ASSERT(sizeof(struct SaveBlock1) <= SECTOR_DATA_SIZE * (SECTOR_ID_SAVEBLOCK1_END - SECTOR_ID_SAVEBLOCK1_START + 1), SaveBlock1FreeSpace);
 STATIC_ASSERT(sizeof(struct PokemonStorage) <= SECTOR_DATA_SIZE * (SECTOR_ID_PKMN_STORAGE_END - SECTOR_ID_PKMN_STORAGE_START + 1), PokemonStorageFreeSpace);
+
+// The blocks above must also physically fit on the flash chip. The GBA save flash is
+// 1 Mbit = 32 sectors; any logical sector id >= 32 aliases bank 0 and corrupts the save.
+STATIC_ASSERT(SECTORS_COUNT <= MAX_PHYSICAL_SECTORS, SaveLayoutExceedsFlashCapacity);
 
 COMMON_DATA u16 gLastWrittenSector = 0;
 COMMON_DATA u32 gLastSaveCounter = 0;


### PR DESCRIPTION
## Symptom (issues #35, #42, #31, #6)
Deposit a Pokémon in a PC box → save → power off → reload → the box is **empty**, while the **Pokédex survives**.

## Root cause (static analysis, high confidence)

The save sector map declares **34 logical sectors**, but the GBA 1 Mbit save flash has only **32 physical sectors** (16 per bank × 2 banks):

| | sectors |
|---|---|
| `NUM_SECTORS_PER_SLOT` 15 × `NUM_SAVE_SLOTS` 2 | 30 |
| Hall of Fame | 2 |
| Trainer Hill (id **32**) + Recorded Battle (id **33**) | 2 |
| **`SECTORS_COUNT`** | **34** |

`agb_flash.c` selects the bank with `sectorNum / 16` and the offset with `sectorNum % 16`, and only two banks exist. So **logical sectors 32 and 33 fold onto bank 0, physical sectors 0 and 1** — which hold slot-1 `SaveBlock2` (Pokédex/trainer) and `SaveBlock1`. Writing the Recorded-Battle or Trainer-Hill sector (after a link/recorded battle, etc.) overwrites the active save slot.

When a `PokemonStorage` sector then fails its checksum on load it is **silently skipped** — `CopySaveSlotData` only copies sectors whose signature *and* checksum match, with no cross-slot fallback for an individual bad sector. The skipped region keeps the zero-initialised EWRAM default (`gPokemonStorage = {0}`) → **empty boxes**. The Pokédex lives in a different, still-valid sector → it survives. That's exactly the reported symptom.

This is corroborated by the code's own documentation, which still describes the correct **32-sector** geometry the constants drifted away from:
- `src/save.c` header comment: `Sectors 0-13 / 14-27 / 28-29 / 30 / 31` and *"all 14 sectors get written"*.
- `struct SaveBlock3` (`include/global.h`): `/* max size 1624 bytes */` == `116 * 14`.

### Ruled out
- **Not** the save-encryption key. Box Pokémon are encrypted with `personality ^ otId` (`EncryptBoxMon`), never with `gSaveBlock2->encryptionKey`; the `// updated twice?` double-assignment in `SavePlayerBag()` is verbatim-vanilla and only touches **bag items**.
- **Not** a plain PokemonStorage overflow — it fits its sectors; the problem is the *total* sector count exceeding the chip.

## Fix
Restore the documented 14-sector / 32-total geometry by reclaiming one sector:
- `include/pokemon_storage_system.h`: `TOTAL_BOXES_COUNT` 14 → **13**, so `struct PokemonStorage` fits in **8** sectors instead of 9.
- `include/save.h`: `NUM_SECTORS_PER_SLOT` 15→14, `SECTORS_COUNT` 34→32, HOF/Trainer-Hill/Recorded-Battle ids back to 28/29/30/31; add `MAX_PHYSICAL_SECTORS 32`.
- `src/save.c`: drop the 9th `PokemonStorage` chunk from `sSaveSlotLayout`; add `STATIC_ASSERT(SECTORS_COUNT <= MAX_PHYSICAL_SECTORS, …)` so this can never silently regress.

All existing `STATIC_ASSERT`s still hold with this build's config (`USE_DEXNAV_SEARCH_LEVELS`/`FNPC_ENABLE_NPC_FOLLOWERS`/`OW_USE_FAKE_RTC`/item-descriptions all off → `SaveBlock3` is 1 byte; `SaveBlock1` unchanged at 5 sectors; `PokemonStorage` 13 boxes ≈ 31734 B ≤ 8 × 3968 = 31744).

## Not compiled here
No devkitARM in this environment — **please build locally and verify in-game**. If you would rather keep 14 boxes, the alternative is to reclaim the sector elsewhere (e.g. trim `SaveBlock1` back to 4 sectors if `sizeof(SaveBlock1) ≤ 15872`); the new `STATIC_ASSERT` will keep you honest either way.

## In-game test plan (RetroArch, battery .sav — not save-states)
1. New game; deposit a Pokémon into **Box 1** and into the **highest box**; save.
2. (Stress variant) trigger a recorded/link battle, then save again.
3. Fully close the ROM and reload → Continue → open the PC.
4. **Pass:** both boxes still contain their Pokémon after reload (and after the recorded-battle variant). HOF + saving twice in a row must also still work.

## Save-format note
Moving box storage down one sector changes save offsets, and box 14 no longer exists; existing saves that used box 14 lose it on migration. Worth a release-note callout.

Fixes #35
Fixes #42
Fixes #31
Fixes #6