### PR TITLE
Fix three Kanto cross-region script softlocks (May's room, Oak's Parcel order, Pewter Jigglypuff)

### DIFF
--- a/data/maps/PalletTown_PlayersHouse_2F_Frlg/scripts.inc
+++ b/data/maps/PalletTown_PlayersHouse_2F_Frlg/scripts.inc
@@ -18,7 +18,16 @@ PalletTown_PlayersHouse_2F_OnWarp::
 PalletTown_PlayersHouse_2F_FirstWarpIn::
 	turnobject LOCALID_PLAYER, DIR_NORTH
 	setvar VAR_MAP_SCENE_PALLET_TOWN_PLAYERS_HOUSE_2F, 1
+	@ Only run the Littleroot-style intro setup for a genuine Kanto-first start (rival arc
+	@ not started yet). A Hoenn-first player who has already met the rival (RIVAL_STATE >= 3)
+	@ and then crosses into Kanto must NOT re-run this: it clears the Littleroot bedroom
+	@ "hide May" flag and rolls VAR_LITTLEROOT_RIVAL_STATE back to 3, so May reappears in the
+	@ Littleroot bedroom and softlocks the room (#7).
+	goto_if_ge VAR_LITTLEROOT_RIVAL_STATE, 3, PalletTown_PlayersHouse_2F_EventScript_SkipIntroSetup
 	goto_if_unset VAR_LITTLEROOT_INTRO_STATE, PalletTown_PlayersHouse_2F_EventScript_SetIntroFlags
+	end
+
+PalletTown_PlayersHouse_2F_EventScript_SkipIntroSetup::
 	end
 
 PalletTown_PlayersHouse_2F_EventScript_NES::

--- a/data/maps/PewterCity_PokemonCenter_1F_Frlg/map.json
+++ b/data/maps/PewterCity_PokemonCenter_1F_Frlg/map.json
@@ -16,7 +16,7 @@
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_JIGGLYPUFF",
-      "x": 2,
+      "x": 3,
       "y": 2,
       "elevation": 3,
       "movement_type": "MOVEMENT_TYPE_FACE_DOWN",

--- a/data/maps/ViridianCity_Mart_Frlg/scripts.inc
+++ b/data/maps/ViridianCity_Mart_Frlg/scripts.inc
@@ -17,6 +17,12 @@ ViridianCity_Mart_OnFrame::
 	.2byte 0
 
 ViridianCity_Mart_EventScript_ParcelScene::
+	@ Don't hand over Oak's Parcel until the player has actually been through Oak's Lab
+	@ and finished the starter/rival scene (VAR_..._OAKS_LAB reaches 4). Crossroads adds a
+	@ cross-region Pokemon Center door, so the player can reach Viridian before the Pallet
+	@ intro; firing this early gives the parcel before the starter and corrupts the order (#17).
+	@ The scene var stays 0 here, so it re-arms and fires correctly once the lab scene advances.
+	goto_if_lt VAR_MAP_SCENE_PALLET_TOWN_PROFESSOR_OAKS_LAB, 4, ViridianCity_Mart_EventScript_ParcelSceneNotReady
 	lockall
 	textcolor NPC_TEXT_COLOR_MALE
 	applymovement LOCALID_VIRIDIAN_MART_CLERK, Common_Movement_WalkInPlaceFasterDown
@@ -31,6 +37,9 @@ ViridianCity_Mart_EventScript_ParcelScene::
 	giveitem_msg ViridianCity_Mart_Text_ReceivedOaksParcelFromClerk, ITEM_OAKS_PARCEL, 1, MUS_RG_OBTAIN_KEY_ITEM
 	setvar VAR_MAP_SCENE_PALLET_TOWN_PROFESSOR_OAKS_LAB, 5
 	releaseall
+	end
+
+ViridianCity_Mart_EventScript_ParcelSceneNotReady::
 	end
 
 ViridianCity_Mart_Movement_ApproachCounter::


### PR DESCRIPTION
Three independent softlocks/ordering bugs that share a theme: Crossroads adds cross-region Pokémon Center doors, which let the player reach Kanto maps out of the order the original FireRed scripts assume.

---

### #7 — Stuck in May's room after crossing regions
`PalletTown_PlayersHouse_2F` `FirstWarpIn` runs `SetIntroFlags` whenever `VAR_LITTLEROOT_INTRO_STATE` is unset. That setup is the Littleroot-style intro: it `clearflag FLAG_HIDE_LITTLEROOT_TOWN_MAYS_HOUSE_RIVAL_BEDROOM` and `setvar VAR_LITTLEROOT_RIVAL_STATE, 3` (`scripts.inc:41,55`). A Hoenn-first player who has already met the rival (`VAR_LITTLEROOT_RIVAL_STATE` = 4) and then crosses into Kanto re-triggers it → May reappears in the Littleroot bedroom and stands by the stairs with no trigger able to advance the scene → softlock.

**Fix:** bail out of the intro setup when `VAR_LITTLEROOT_RIVAL_STATE >= 3`. A genuine Kanto-first start has `RIVAL_STATE` 0 at this point, so it still initialises normally; only an already-progressed player is protected.

> Note (not code-fixed here): the issue also mentions *"no starting-town choice."* The region choice does exist — it's the **Select** toggle between the Hoenn and Kanto title screens (`src/title_screen.c:800` / `src/title_screen_frlg.c:500`) — but nothing on screen signposts it, so pressing A/Start silently commits to whichever title is showing (Hoenn by default). Recommend adding a visible "Press SELECT: Kanto / Hoenn" hint to the title screen; left to you since it's a UI change and not the softlock.

### #17 — Oak's Parcel handed over before the starter
`ViridianCity_Mart_OnFrame` fires `ParcelScene` purely on `VAR_MAP_SCENE_VIRIDIAN_CITY_MART == 0` (`scripts.inc:15-16`) with no story precondition. In vanilla FireRed the player is fenced into Pallet by Oak's Route-1 block until the lab/starter scene completes; the cross-region Viridian Pokémon Center door bypasses that fence. Reaching the Mart early hands over `ITEM_OAKS_PARCEL`, and the lab turn-in branch — gated only on `goto_if_ge VAR_MAP_SCENE_VIRIDIAN_CITY_MART, 1` (`PalletTown_ProfessorOaksLab_Frlg/scripts.inc:576`) — then runs the Pokédex scene before the starter is given (the "rival ran off without a Pokémon, starter choice disabled" report).

**Fix:** guard `ParcelScene` with `goto_if_lt VAR_MAP_SCENE_PALLET_TOWN_PROFESSOR_OAKS_LAB, 4, …NotReady`. The lab scene reaches 4 only after the starter + rival battle, which is also the earliest the player can legitimately leave Pallet. If reached early the scene no-ops and the var stays 0, so it re-arms and fires in the correct order.

### #25 — Pewter Jigglypuff blocks the Petalburg→Pewter return
The custom Petalburg↔Pewter Pokémon Center link lands the player on Pewter `PokemonCenter_1F` warp id 4 at tile `(2,1)` (`PetalburgCity_PokemonCenter_1F/map.json` warp 3 → dest 4). A flagless (`"flag": "0"`) Jigglypuff object event sits on `(2,2)` — the only walkable step-off tile — sealing the player in. (Normal Pewter front-door entry uses warp id 1, so the trap is exclusive to this cross-region link.) This is **not** the trainer-flag aliasing bug — the object has no hide flag.

**Fix:** move the Jigglypuff one tile to the adjacent free tile `(3,2)`; `(2,2)` is freed and the sing gag still works.

---

### Test plan (RetroArch, in-game)
- **#7:** Hoenn-first full intro (meet May, get starter + Pokédex). Cross to Kanto, take a Kanto starter, return to Littleroot → enter May's House → go upstairs → confirm May is **not** blocking and you can leave; confirm Mom doesn't re-issue "go meet May." Then verify a fresh **Kanto-first** start still runs its intro normally.
- **#17:** New game → reach Viridian Mart early via the cross-region PC door → clerk gives **no** parcel. Do Oak's Lab (starter + rival), then revisit the Mart → clerk **now** gives the parcel → deliver to Oak → Pokédex scene once. Starter must be in party throughout.
- **#25:** From Petalburg PC step into the top-left warp → arrive in Pewter PC → confirm you can step down and leave; talk to the Jigglypuff to confirm the gag still triggers; normal Pewter front-door entry unchanged.

Static analysis only — no devkitARM in this environment, please build + playtest.

Fixes #7
Fixes #17
Fixes #25