### PR TITLE
Fix HM forgetting, Flight Call icon, Magikarp rename, and FRLG tutorial name

### DIFF
--- a/data/maps/Route4_PokemonCenter_1F_Frlg/scripts.inc
+++ b/data/maps/Route4_PokemonCenter_1F_Frlg/scripts.inc
@@ -70,6 +70,10 @@ Route4_PokemonCenter_1F_EventScript_BuyMagikarpPC::
 	goto_if_eq VAR_RESULT, NO, Route4_PokemonCenter_1F_EventScript_TransferMagikarpCloseMoneyBox
 	fadescreen FADE_TO_BLACK
 	hidemoneybox
+	@ Magikarp went to the PC (party was full). Point the nickname at that boxed mon
+	@ (its box/pos are already in gSpecialVar_MonBoxId/Pos from the deposit); without this
+	@ ChangePokemonNickname renames a stale PARTY slot instead -- the "renamed my Mankey" bug (#18).
+	setvar VAR_0x8004, PC_MON_CHOSEN
 	special ChangePokemonNickname
 	waitstate
 	lock

--- a/include/config/pokemon.h
+++ b/include/config/pokemon.h
@@ -55,7 +55,11 @@
 #define P_EV_CAP                         GEN_LATEST  // Since Gen 6, the max EVs per stat is 252 instead of 255.
 #define P_SHOW_TERA_TYPE                 GEN_8       // Since Gen 9, the Tera Type is shown on the summary screen.
 #define P_TM_LITERACY                    GEN_LATEST  // Since Gen 6, TM illiterate Pokémon can learn TMs that teach moves that are in their level-up learnsets.
-#define P_CAN_FORGET_HIDDEN_MOVE         FALSE       // If TRUE, Pokémon can forget any move, even if it is an HM.
+#define P_CAN_FORGET_HIDDEN_MOVE         TRUE        // If TRUE, Pokémon can forget any move, even if it is an HM.
+                                                     // Needed here: Rock Smash is an HM (FOREACH_HM) yet is a normal
+                                                     // level-up move for many species (e.g. Mudkip), so it could be
+                                                     // learned but never deleted (#21). Forgotten field moves stay
+                                                     // re-teachable via the Move Reminder / HM items.
 #define P_ASK_MOVE_CONFIRMATION          FALSE       // If FALSE, when a player decides not to learn a move, the game does not ask the player for confirmation.
 #define P_EGG_CYCLE_LENGTH               GEN_LATEST  // Since Gen 8, Egg cycles take half as many steps as before. Previous generations have some varied step counts around 255.
 #define P_ONLY_OBTAINABLE_SHINIES        FALSE       // If TRUE, Pokémon encountered in the Battle Pyramid or while catching is disabled won't be Shiny.

--- a/src/battle_message.c
+++ b/src/battle_message.c
@@ -2406,6 +2406,8 @@ static const struct BattleWindowText *const sBattleTextOnWindowsInfo[] =
 
 static const u8 sRecordedBattleTextSpeeds[] = {8, 4, 1, 0};
 
+static const u8 sText_OldManUsedItem[] = _("The OLD MAN used {B_LAST_ITEM}!");
+
 void BufferStringBattle(enum StringID stringID, enum BattlerId battler)
 {
     s32 i;
@@ -2881,6 +2883,11 @@ void BufferStringBattle(enum StringID stringID, enum BattlerId battler)
         break;
     case STRINGID_TRAINERSLIDE:
         stringPtr = gBattleStruct->trainerSlideMsg;
+        break;
+    case STRINGID_WALLYUSEDITEM:
+        // The FRLG catching tutorial reuses Wally's ball-throw script; in Kanto the
+        // demonstrator is the old man, not Wally (#22). Hoenn keeps "WALLY used ...".
+        stringPtr = isFrlg ? sText_OldManUsedItem : gBattleStringsTable[STRINGID_WALLYUSEDITEM];
         break;
     default: // load a string from the table
         if (stringID >= STRINGID_COUNT)

--- a/src/region_map.c
+++ b/src/region_map.c
@@ -1812,7 +1812,11 @@ void CreateRegionMapPlayerIcon(u16 tileTag, u16 paletteTag)
     struct SpritePalette palette = {sRegionMapPlayerIcon_BrendanPal, paletteTag};
     struct SpriteTemplate template = {tileTag, paletteTag, &sRegionMapPlayerIconOam, sRegionMapPlayerIconAnimTable, NULL, gDummySpriteAffineAnimTable, SpriteCallbackDummy};
 
-    if (IsEventIslandMapSecId(gMapHeader.regionMapSectionId))
+    // On a forced-flight map (Flight Call showing a region the player isn't standing in) the
+    // "you are here" icon would be parked on that region's first heal point with the wrong-region
+    // sprite, e.g. flying from Hoenn shows the player sitting on Pallet Town (#30). Suppress it,
+    // same as for event islands.
+    if (IsEventIslandMapSecId(gMapHeader.regionMapSectionId) || sUseForcedFlightRegion)
     {
         sRegionMap->playerIconSprite = NULL;
         return;


### PR DESCRIPTION
Four independent gameplay bugs.

### #21 — A Pokémon can learn Rock Smash by level-up but can never forget it
`CannotForgetMove()` returns `IsMoveHM(move)` when `P_CAN_FORGET_HIDDEN_MOVE` is FALSE (`src/pokemon.c:5391`), and Rock Smash is listed in `FOREACH_HM` (`include/constants/tms_hms.h:62`). But Rock Smash is also a normal level-up move for many species (e.g. Mudkip learns it at L6, `src/data/pokemon/level_up_learnsets/gen_9.h`), so it gets learned and can then never be deleted via the party menu or the Move Deleter.

**Fix:** set `P_CAN_FORGET_HIDDEN_MOVE = TRUE` (`include/config/pokemon.h:58`). This matches modern-expansion behavior; forgotten field moves stay re-teachable via the Move Reminder / HM items, and Rock Smash still works as a field move (gated by the badge, not the HM list).
**Scoped alternative for you:** drop `F(ROCK_SMASH)` from `FOREACH_HM`. That's narrower, but the HM item↔move tables (`include/item.h:128-162`) and `ITEM_HM_ROCK_SMASH` are *generated* from `FOREACH_HM`, so it renumbers the HMs and needs a careful rebuild — hence the config flag is the lower-risk change here.

### #30 — Flight Call shows the wrong starting city (Hoenn → Pallet Town)
For a forced flight to a region you aren't standing in (`sUseForcedFlightRegion`), `CreateRegionMapPlayerIcon` (`src/region_map.c:1815`) still drew the player "you are here" icon — positioned on that region's first heal point (Kanto = Pallet Town) and with the wrong-region sprite. So Flight Call from Hoenn shows you sitting on Pallet Town.

**Fix:** suppress the player icon when `sUseForcedFlightRegion` is set, the same way event-island maps already do. (The destination warp table itself is correct and region-aware, so a city you actively select still lands correctly.)

### #18 — Buying the overpriced Magikarp renames a different party Pokémon
In `Route4_PokemonCenter_1F_Frlg`, when the party is full the Magikarp is sent to the PC (`BuyMagikarpPC`), but that branch calls `special ChangePokemonNickname` **without** setting `VAR_0x8004`. `GetSelectedBoxMonFromPcOrParty` (`src/pokemon.c:6778`) then falls into the party branch and renames `gParties[0][stale VAR_0x8004]` — the reporter's Mankey — instead of the boxed Magikarp.

**Fix:** set `VAR_0x8004 = PC_MON_CHOSEN` before the nickname (the box id/pos were already stored by the deposit at `src/pokemon.c:2970`), matching the existing `Common_EventScript_NameReceivedBoxMon` helper. Now the naming screen targets the boxed Magikarp.

### #22 — FRLG catching tutorial calls the old man "Wally" (cosmetic)
The Kanto catching tutorial reuses Wally's ball-throw script (`data/battle_scripts_2.s` → `BattleScript_BallThrowByWally`), which prints `STRINGID_WALLYUSEDITEM` = `"WALLY used …"` (`src/battle_message.c:421`). In Kanto the demonstrator is the old man, not Wally.

**Fix:** add a region-aware case in `BufferStringBattle` so `isFrlg` prints "The OLD MAN used …" while Hoenn keeps "WALLY used …".

---

### In-game test plan (RetroArch)
- **#21:** teach/learn Rock Smash on a Mudkip → try to forget it in the party menu and at the Move Deleter → it can now be deleted; confirm a *real* HM (e.g. Cut) is still forgettable too, and Rock Smash still smashes rocks with the badge.
- **#30:** use Flight Call from Hoenn and pick Kanto → no player icon parked on Pallet Town; select a city → you land there. Normal Fly is unaffected.
- **#18:** fill the party (include a Mankey), buy the Magikarp so it goes to the PC, choose to nickname → the **Magikarp** is named, the Mankey is untouched. Re-test with a non-full party (Magikarp to party) → still correct.
- **#22:** trigger the Viridian old-man catching tutorial → ball-throw line reads "The OLD MAN used POKé BALL!"; confirm Hoenn's Wally tutorial still says "WALLY used …".

Static analysis only — no devkitARM in this environment, please build + playtest.

Fixes #21
Fixes #30
Fixes #18
Fixes #22